### PR TITLE
Change from strict Hashie::Dash to more flexible Hashie::Mash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: false
 language: ruby
 rvm:
   - 2.2.2
+  - 2.3.0
+  - 2.4.0
+  - 2.5.0
 before_install: gem install bundler -v 1.14.6
 notifications:
   email:

--- a/lib/otc/asgroup.rb
+++ b/lib/otc/asgroup.rb
@@ -1,7 +1,7 @@
 require "hashie"
 
 module Otc
-  class ASGroup < Hashie::Dash
+  class ASGroup < Hashie::Mash
     class << self
       def query_all(name: nil)
         response = Request.get service: "as", path: "/autoscaling-api/v1/#{Configuration.project!}/scaling_group?scaling_group_name=#{name}"
@@ -14,14 +14,6 @@ module Otc
         query_all(name: name).first
       end
     end
-
-    [
-      "networks", "detail", "notifications", "scaling_group_name", "scaling_group_id", "scaling_group_status",
-      "scaling_configuration_id", "scaling_configuration_name", "current_instance_number", "desire_instance_number",
-      "min_instance_number", "max_instance_number", "cool_down_time", "lb_listener_id", "lbaas_listeners",
-      "cloud_location_id", "available_zones", "security_groups", "create_time", "vpc_id", "health_periodic_audit_method",
-      "health_periodic_audit_time", "instance_terminate_policy", "is_scaling", "delete_publicip"
-    ].each { |prop| property prop }
 
     def instances
       @_instances ||= begin

--- a/lib/otc/asgroup_instance.rb
+++ b/lib/otc/asgroup_instance.rb
@@ -1,11 +1,6 @@
 require "hashie"
 
 module Otc
-  class ASGroupInstance < Hashie::Dash
-    [
-      "instance_id", "scaling_group_id", "scaling_group_name", "life_cycle_state", "health_status",
-      "scaling_configuration_name", "scaling_configuration_id", "create_time", "instance_name",
-      "protect_from_scaling_down"
-    ].each { |prop| property prop }
+  class ASGroupInstance < Hashie::Mash
   end
 end

--- a/lib/otc/ecs.rb
+++ b/lib/otc/ecs.rb
@@ -1,14 +1,11 @@
 require "hashie"
 
 module Otc
-  class ECS < Hashie::Dash
+  class ECS < Hashie::Mash
     class << self
       def query_all(name: nil)
         response = Request.get service: "ecs", path: "/v2/#{Configuration.project!}/servers/detail?name=#{name}"
         JSON.parse(response.body)["servers"].map do |server|
-          keys_to_delete = server.keys - ECS::ATTRIBUTES
-          keys_to_delete.each { |key| server.delete(key) }
-
           ECS.new(server)
         end
       end
@@ -17,13 +14,6 @@ module Otc
         query_all(name: name).first
       end
     end
-
-    ATTRIBUTES = [
-      "name", "id", "status", "created", "updated", "flavor", "image", "tenant_id", "key_name", 
-      "user_id", "metadata", "hostId", "addresses", "security_groups", "tags", "links", "progress"
-    ]
-
-    ATTRIBUTES.each { |prop| property prop }
 
     def public_ip
       @_public_ip ||= begin

--- a/lib/otc/eip.rb
+++ b/lib/otc/eip.rb
@@ -1,7 +1,7 @@
 require "hashie"
 
 module Otc
-  class EIP < Hashie::Dash
+  class EIP < Hashie::Mash
     class << self
       def query_all
         response = Request.get service: "ecs", path: "/v1/#{Configuration.project!}/publicips"
@@ -10,11 +10,5 @@ module Otc
         end
       end
     end
-
-    [
-      "id", "status", "type", "port_id", "public_ip_address", "private_ip_address",
-      "tenant_id", "create_time", "bandwidth_id", "bandwidth_share_type", "bandwidth_size",
-      "profile", "bandwidth_name"
-    ].each { |prop| property prop }
   end
 end


### PR DESCRIPTION
The OTC API is always chaging therefore we need to update this gem sometimes. It's better to switch to `Hashie::Mash` so we don't have to update the gem when the API changes.